### PR TITLE
Repository Settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,80 @@
+root = true
+
+## Repository Configurations
+############################
+[.{git*,editorconfig,*.yml}]
+end_of_line = lf
+indent_style = space
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[.gitmodules]
+indent_style = tab
+
+[.gitkeep]
+insert_final_newline = unset
+
+
+## PureBasic
+############
+[*.{pb,pbi,pbf}]
+charset = utf-8-bom
+indent_style = space
+indent_size = unset
+end_of_line = unset
+insert_final_newline = true
+trim_trailing_whitespace = unset
+
+
+## Markdown GFM
+###############
+[*.md]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Shell Scripts
+################
+[*.sh]
+end_of_line = lf
+indent_style = tab
+indent_size = unset
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Batch Scripts
+################
+[*.{bat,cmd}]
+indent_style = tab
+indent_size = unset
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+## Plain-Text Files
+###################
+[*.txt]
+indent_style = space
+indent_size = unset
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+
+[{LICENSE,README}]
+indent_size = unset
+indent_style = space
+end_of_line = unset
+trim_trailing_whitespace = true
+insert_final_newline = true
+

--- a/.gitattributes
+++ b/.gitattributes
@@ -39,6 +39,7 @@
 
 ## Documentation Files
 ######################
+*.asc        text
 *.adoc       text
 *.asciidoc   text
 *.md         text

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,64 @@
 
+## PureBasic
+############
+*.pb.cfg
+*.pbi.cfg
+*.pbp
+project.cfg
+
+
+## Binary files
+###############
+
+# Object files
+# ------------
+*.elf
+*.ko
+*.o
+*.obj
+
+# Static libraries
+# ----------------
+*.a
+*.la
+*.lib
+*.lo
+
+# Shared objects
+# --------------
+*.dll
+*.dylib
+*.so
+*.so.*
+
+# Executables
+# -----------
+*.app
+*.exe
+*.out
+
+## Misc Work Files
+##################
+
+# Temporary/backup or removed files and folders:
+___*
+___*.*
+
+# Links and URLs
+*.lnk
+*.url
+
+
+## Apps Local Settings & Temp Files
+###################################
+
+# Chrome's debug logs for local HTML pages:
+debug.log
+
+############################
+## COMMON IGNORE PATTERNS ##
+############################
+
 # Created by https://www.toptal.com/developers/gitignore/api/windows,linux,macos,purebasic
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,linux,macos,purebasic
 
@@ -46,23 +106,6 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-### PureBasic ###
-# PureBasic
-
-# Settings files
-*.pb.cfg
-*.pbi.cfg
-project.cfg
-
-# Shared libraries
-*.so
-*.dylib
-*.dll
-
-# Binary executables
-*.exe
-*.app
-*.out
 
 ### Windows ###
 # Windows thumbnail cache files
@@ -87,7 +130,5 @@ $RECYCLE.BIN/
 *.msm
 *.msp
 
-# Windows shortcuts
-*.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/windows,linux,macos,purebasic


### PR DESCRIPTION
Repository Settings

Add a few more rules to `.gitignore` and move PB and binaries rules to
the top so that it's easier to add exceptions. More binary files rules.

Add basic EditorConfig settings covering file types useful for this repo
but don't enforce trimming trailing space for PB sources (because the
PB IDE indents empty lines).